### PR TITLE
Update CMake GLEW package linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ target_compile_options(vec3_test PRIVATE
 )
 
 target_link_libraries(${PROJECT_NAME} PUBLIC
-	GLEW
+	GLEW::GLEW
     	GL
     	glfw
 	pthread


### PR DESCRIPTION
This seems to be required to play nicely with GLEW as installed by vcpkg.
@rjgon01 / @BWOOD738 can you look into it more to understand why?